### PR TITLE
replace DT::F::MySQL tp DT::F::Japanese

### DIFF
--- a/static/modules/datetime.html
+++ b/static/modules/datetime.html
@@ -121,7 +121,7 @@ say DateTime::Format::W3CDTF-&gt;format_datetime($dt)
 $dt = DateTime::Format::W3CDTF-&gt;parse_datetime('2008-08-04T15:00:00+09:00');
 </code></pre>
 
-<p>DateTime::Format::*には他にもDateTime::Format::MySQLなどがあります。</p>
+<p>DateTime::Format::*には他にもDateTime::Format::Japaneseなどがあります。</p>
 
 <!-- content end -->
         <hr />


### PR DESCRIPTION
replace DT::F::MySQL tp DT::F::Japanese.
Because DT::F::MySQL is broken with MySQL 5.1.[1]

[1] https://rt.cpan.org/Public/Bug/Display.html?id=43137

今はもう使えない感じで、修正もされなさそうなので有用なものに置き換え。
